### PR TITLE
Adapted `build.gradle` to latest version of React Native

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
-    minSdkVersion 16
+    minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : 16
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "28.0.3"
-        minSdkVersion = 16
+        minSdkVersion = rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : 16
         compileSdkVersion = 28
         targetSdkVersion = 28
     }


### PR DESCRIPTION
This library breaks the android build of the latest version of react native due to the min sdk version being incompatible. This PR fixes this.