### PR TITLE
[Android] Fix unsubscribe all listeners when invoke stopScreenshotDetection

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ React.useEffect(() => {
   const userDidScreenshot = () => {
     console.log('User took screenshot');
   };
-  const listener = addScreenshotListener(userDidScreenshot);
+  const unsubscribe = addScreenshotListener(userDidScreenshot);
   return () => {
-    removeScreenshotListener(listener);
+    unsubscribe();
   };
 }, []);
 ```

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -6,10 +6,7 @@ import {
   PermissionsAndroid,
   Platform,
 } from 'react-native';
-import {
-  addScreenshotListener,
-  removeScreenshotListener,
-} from 'react-native-detector';
+import { addScreenshotListener } from 'react-native-detector';
 
 export default function App() {
   const [screenshotCounter, setScreenshotCounter] = React.useState<number>(0);
@@ -31,9 +28,9 @@ export default function App() {
     const userDidScreenshot = () => {
       setScreenshotCounter((screenshotCounter) => screenshotCounter + 1);
     };
-    const eventEmitter = addScreenshotListener(userDidScreenshot);
+    const unsubscribe = addScreenshotListener(userDidScreenshot);
     return () => {
-      removeScreenshotListener(eventEmitter);
+      unsubscribe();
     };
   }, []);
 

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,1 +1,165 @@
-it.todo('write a test');
+import { NativeEventEmitter, NativeModules, Platform } from 'react-native';
+
+describe('addScreenshotListener', () => {
+  const createIsolatedTest = (
+    type: 'ios' | 'android',
+    isolatedTest: (options: {
+      addScreenshotListener: (listener: () => void) => () => void;
+      emitScreenshot: () => void;
+    }) => void
+  ) => () => {
+    jest.isolateModules(() => {
+      NativeModules.Detector = {
+        addListener: jest.fn(),
+        removeListeners: jest.fn(),
+        startScreenshotDetection: jest.fn(),
+        stopScreenshotDetection: jest.fn(),
+      };
+
+      const emitter = new NativeEventEmitter(NativeModules.Detector);
+
+      Platform.select = (spec: any) => spec[type];
+
+      const { addScreenshotListener } = require('../index');
+
+      const emitScreenshot = () => {
+        emitter.emit('UIApplicationUserDidTakeScreenshotNotification');
+      };
+
+      isolatedTest({ addScreenshotListener, emitScreenshot });
+    });
+  };
+
+  describe('iOS', () => {
+    it(
+      'should invoke each passed listener',
+      createIsolatedTest('ios', ({ emitScreenshot, addScreenshotListener }) => {
+        const listener1 = jest.fn();
+        const listener2 = jest.fn();
+
+        addScreenshotListener(listener1);
+        addScreenshotListener(listener2);
+
+        emitScreenshot();
+
+        expect(listener1).toHaveBeenCalledTimes(1);
+        expect(listener2).toHaveBeenCalledTimes(1);
+      })
+    );
+
+    it(
+      'should not invoke passed listener when unsubscribe',
+      createIsolatedTest('ios', ({ emitScreenshot, addScreenshotListener }) => {
+        const listener = jest.fn();
+
+        const unsubscribe = addScreenshotListener(listener);
+
+        emitScreenshot();
+
+        expect(listener).toHaveBeenCalledTimes(1);
+
+        unsubscribe();
+
+        emitScreenshot();
+
+        expect(listener).toHaveBeenCalledTimes(1);
+      })
+    );
+  });
+
+  describe('Android', () => {
+    it(
+      'should invoke each passed listener',
+      createIsolatedTest(
+        'android',
+        ({ emitScreenshot, addScreenshotListener }) => {
+          const listener1 = jest.fn();
+          const listener2 = jest.fn();
+
+          addScreenshotListener(listener1);
+          addScreenshotListener(listener2);
+
+          emitScreenshot();
+
+          expect(listener1).toHaveBeenCalledTimes(1);
+          expect(listener2).toHaveBeenCalledTimes(1);
+        }
+      )
+    );
+
+    it(
+      'should not invoke passed listener when unsubscribe',
+      createIsolatedTest(
+        'android',
+        ({ emitScreenshot, addScreenshotListener }) => {
+          const listener = jest.fn();
+
+          const unsubscribe = addScreenshotListener(listener);
+
+          emitScreenshot();
+
+          expect(listener).toHaveBeenCalledTimes(1);
+
+          unsubscribe();
+
+          emitScreenshot();
+
+          expect(listener).toHaveBeenCalledTimes(1);
+        }
+      )
+    );
+
+    it(
+      'should invoke startScreenshotDetection once when add listeners',
+      createIsolatedTest('android', ({ addScreenshotListener }) => {
+        const { startScreenshotDetection } = NativeModules.Detector;
+
+        addScreenshotListener(jest.fn());
+        addScreenshotListener(jest.fn());
+        addScreenshotListener(jest.fn());
+
+        expect(startScreenshotDetection).toHaveBeenCalledTimes(1);
+      })
+    );
+
+    it(
+      'should invoke stopScreenshotDetection when no JS listeners',
+      createIsolatedTest('android', ({ addScreenshotListener }) => {
+        const { stopScreenshotDetection } = NativeModules.Detector;
+
+        const unsubscribe1 = addScreenshotListener(jest.fn());
+        const unsubscribe2 = addScreenshotListener(jest.fn());
+        const unsubscribe3 = addScreenshotListener(jest.fn());
+
+        unsubscribe1();
+
+        expect(stopScreenshotDetection).toHaveBeenCalledTimes(0);
+
+        unsubscribe2();
+
+        expect(stopScreenshotDetection).toHaveBeenCalledTimes(0);
+
+        unsubscribe3();
+
+        expect(stopScreenshotDetection).toHaveBeenCalledTimes(1);
+      })
+    );
+
+    it(
+      'should restore screenshot detection when resubscribe',
+      createIsolatedTest('android', ({ addScreenshotListener }) => {
+        const { startScreenshotDetection } = NativeModules.Detector;
+
+        const unsubscribe = addScreenshotListener(jest.fn());
+
+        unsubscribe();
+
+        expect(startScreenshotDetection).toHaveBeenCalledTimes(1);
+
+        addScreenshotListener(jest.fn());
+
+        expect(startScreenshotDetection).toHaveBeenCalledTimes(2);
+      })
+    );
+  });
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,23 +1,57 @@
 import { NativeModules, NativeEventEmitter, Platform } from 'react-native';
+
 const { Detector } = NativeModules;
 
 enum EventsName {
   UserDidTakeScreenshot = 'UIApplicationUserDidTakeScreenshotNotification',
 }
 
-export function addScreenshotListener(callback: Function) {
-  if (Platform.OS === 'android') Detector.startScreenshotDetection();
-  const eventEmitter = new NativeEventEmitter(Detector);
-  eventEmitter.addListener(
+const detectorEventEmitter = new NativeEventEmitter(Detector);
+
+type Unsubscribe = () => void;
+
+const commonAddScreenshotListener = (listener: () => void): Unsubscribe => {
+  const eventSubscription = detectorEventEmitter.addListener(
     EventsName.UserDidTakeScreenshot,
-    () => callback(),
+    () => listener(),
     {}
   );
 
-  return eventEmitter;
-}
+  return () => {
+    eventSubscription.remove();
+  };
+};
 
-export function removeScreenshotListener(eventEmitter: NativeEventEmitter) {
-  eventEmitter.removeAllListeners(EventsName.UserDidTakeScreenshot);
-  if (Platform.OS === 'android') Detector.stopScreenshotDetection();
-}
+const getListenersCount = (): number => {
+  return (
+    // React Native 0.64+
+    // @ts-ignore
+    detectorEventEmitter.listenerCount?.(EventsName.UserDidTakeScreenshot) ??
+    // React Native < 0.64
+    // @ts-ignore
+    detectorEventEmitter.listeners?.(EventsName.UserDidTakeScreenshot).length ??
+    0
+  );
+};
+
+export const addScreenshotListener = Platform.select<
+  (listener: () => void) => Unsubscribe
+>({
+  default: (): Unsubscribe => () => {},
+  ios: commonAddScreenshotListener,
+  android: (listener: () => void): Unsubscribe => {
+    if (getListenersCount() === 0) {
+      Detector.startScreenshotDetection();
+    }
+
+    const unsubscribe: Unsubscribe = commonAddScreenshotListener(listener);
+
+    return () => {
+      unsubscribe();
+
+      if (getListenersCount() === 0) {
+        Detector.stopScreenshotDetection();
+      }
+    };
+  },
+});


### PR DESCRIPTION
This PR change subscription api, now 

- [creating an contentObserver](https://github.com/AzizAK/react-native-detector/blob/8193d013864c178222813ac9864ca1517df356c4/android/src/main/java/com/reactnativedetector/ScreenshotDetectionDelegate.kt#L24-L36) instance (`ContentObserver(onChange)`) will be once (on first `addScreenshotListener()` invoke)

- and [unregistering on native side  ](https://github.com/AzizAK/react-native-detector/blob/8193d013864c178222813ac9864ca1517df356c4/android/src/main/java/com/reactnativedetector/ScreenshotDetectionDelegate.kt#L44-L47) `unregisterContentObserver(contentObserver)` will only when no JS listeners

> see tests...

because of issue:

I have two places in the app where listeners will be added and unmounting one of them trigger `stopScreenshotDetection`

https://github.com/AzizAK/react-native-detector/blob/8193d013864c178222813ac9864ca1517df356c4/src/index.tsx#L20-L23

and another screen that still mounter stop receiving events untill `Detector.startScreenshotDetection();` will be invoked 

```tsx

const Screen1 = ()=>{
  React.useEffect(() => {
    const eventEmitter = addScreenshotListener(listener);
    return () => removeScreenshotListener(eventEmitter);
  }, []);
// ...
}

const Screen2 = ()=>{
  React.useEffect(() => {
    const eventEmitter = addScreenshotListener(listener);
    return () => removeScreenshotListener(eventEmitter);
  }, []);
// ...
}

```