### PR TITLE
[Fix][Android] Error: 'onChange' overrides nothing on react-native@0.65.x

### DIFF
--- a/android/src/main/java/com/reactnativedetector/ScreenshotDetectionDelegate.kt
+++ b/android/src/main/java/com/reactnativedetector/ScreenshotDetectionDelegate.kt
@@ -22,9 +22,9 @@ class ScreenshotDetectionDelegate(val context: Context, val listener: Screenshot
 
     fun startScreenshotDetection() {
         contentObserver = object : ContentObserver(Handler()) {
-            override fun onChange(selfChange: Boolean, uri: Uri) {
+            override fun onChange(selfChange: Boolean, uri: Uri?) {
                 super.onChange(selfChange, uri)
-                if (isReadExternalStoragePermissionGranted()) {
+                if (isReadExternalStoragePermissionGranted() && uri != null) {
                     val path = getFilePathFromContentResolver(context, uri)
                     if (isScreenshotPath(path)) {
                         onScreenCaptured(path!!)


### PR DESCRIPTION
Issue: https://github.com/AzizAK/react-native-detector/issues/22

tested on a real device:

- [x] react-native@0.65.x listener work as expected **(build error is gone)**
- [x] react-native@0.64.x listener work as expected