### PR TITLE
Take project root minSdkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,13 +29,12 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
-    minSdkVersion 16
+    minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"
-    
   }
-  
+
   buildTypes {
     release {
       minifyEnabled false

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,3 +2,4 @@ Detector_kotlinVersion=1.3.50
 Detector_compileSdkVersion=28
 Detector_buildToolsVersion=28.0.3
 Detector_targetSdkVersion=28
+Detector_minSdkVersion=16


### PR DESCRIPTION
Hey hey !

I can't use this lib because I can't override the minSdkVersion at the root level (typically the `uses-sdk:minSdkVersion 16 cannot be smaller than version XX declared in library` error)

Is there any reason to force this at 16 ?

(Tested locally on this branch and it works fine)