### PR TITLE
[FIX] Native module cannot be null error

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ enum EventsName {
   UserDidTakeScreenshot = 'UIApplicationUserDidTakeScreenshotNotification',
 }
 
-const detectorEventEmitter = new NativeEventEmitter();
+const detectorEventEmitter = new NativeEventEmitter(Detector);
 
 type Unsubscribe = () => void;
 


### PR DESCRIPTION
### issue #36 

Change to `detectorEventEmitter` in PR #33 caused crash on iOS. Tested this on real devices and seems to be working without issues. Credit to @crherman7 for pointing this out to me.

### Environment Info

iOS version 15.1
android version 10
React native version: 0.63.3