### PR TITLE
fix: adds Android 14+ implementation and fixes native module cannot b…

### DIFF
--- a/android/src/main/java/com/reactnativedetector/DetectorModule.kt
+++ b/android/src/main/java/com/reactnativedetector/DetectorModule.kt
@@ -4,29 +4,34 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.modules.core.DeviceEventManagerModule
-
-
+import android.app.Activity
 
 class DetectorModule(val reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext), ScreenshotDetectionListener {
-    private val screenshotDetectionDelegate = ScreenshotDetectionDelegate(reactContext, this)
+    private var screenshotDetectionDelegate: ScreenshotDetectionDelegate? = null
+
     override fun getName(): String {
         return "Detector"
     }
 
     @ReactMethod
     fun startScreenshotDetection() {
-        screenshotDetectionDelegate.startScreenshotDetection()
+        val currentActivity = reactContext.currentActivity
+        if (currentActivity != null) {
+            screenshotDetectionDelegate = ScreenshotDetectionDelegate(currentActivity, this)
+            screenshotDetectionDelegate?.startScreenshotDetection()
+        }
     }
 
     @ReactMethod
     fun stopScreenshotDetection() {
-        screenshotDetectionDelegate.stopScreenshotDetection()
+        screenshotDetectionDelegate?.stopScreenshotDetection()
+        screenshotDetectionDelegate = null;
     }
 
     override fun onScreenCaptured(path: String) {
         reactContext
-                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
-                .emit("UIApplicationUserDidTakeScreenshotNotification", null)
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+            .emit("UIApplicationUserDidTakeScreenshotNotification", null)
     }
 
     override fun onScreenCapturedWithDeniedPermission() {


### PR DESCRIPTION
Had to include these code changes as a patch in my repo to get this library to work on Android 14:
- Fixes native module cannot be null error, uses code from this [PR](https://github.com/AzizAK/react-native-detector/pull/41) 
- Fixes Android 14+ implementation using fixes from [here](https://github.com/AzizAK/react-native-detector/issues/66)